### PR TITLE
First CONTRIBUTORS file.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,0 +1,17 @@
+Contributors
+============
+
+This package was the result of collaborative dissussion and effort between:
+
+* Brad Brown @bradsbrown
+* Ryan Casperson @rbcasperson
+* Lewis Franklin @brolewis
+* Doug Philips @dgou
+
+and was based-on the ideas from several similar packages written by them individually.
+
+
+* The initial code which supported Python 2.7 and 3.5+ was done by Doug Philips @dgou
+* Support for environment variable override info to be in any config file was added by Ryan Casperson @rbcasperson
+* Support for copying master.config sections to the returned loaded config was added by Ryan Casperson @rbcasperson
+* The conversion of this repo to Python 3.6+ and a public repo based on poetry was done by Ryan Casperson @rbcasperson

--- a/sphinx_docs/index.rst
+++ b/sphinx_docs/index.rst
@@ -23,6 +23,7 @@ Maintainer's Documentation
 .. toctree::
 
     MAINTAINER
+    CONTRIBUTORS
 
 
 


### PR DESCRIPTION
First version.
Fighting with rST formatting late at night, and rST is winning, but this doesn't look too bad when rendered by the GitHub rST file formatter, and not too bad when the docs are built.

Assigning to the three people my archeology indicates were involved in this to make sure they're happy with the level of info and to have a chance to correct/amend/etc. any mistakes or missing info.