### PR TITLE
Install munch extra so self_check.py will pass.

### DIFF
--- a/env_setup.py
+++ b/env_setup.py
@@ -8,7 +8,10 @@ Runs the following commands:
 import argparse
 from subprocess import check_call
 
-commands_to_run = [["poetry", "install"], ["poetry", "run", "pre-commit", "install"]]
+commands_to_run = [
+    ["poetry", "install", "-E", "munch"],
+    ["poetry", "run", "pre-commit", "install"],
+]
 
 __doc__ = __doc__.format("\n".join(map(" ".join, commands_to_run)))
 


### PR DESCRIPTION
Without this PR I was getting this error when running self_check.py in a freshly setup venv:
```
$ ./self_check.py 
poetry run pre-commit run -a
black....................................................................Passed
Flake8...................................................................Passed
poetry run pytest .
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
rootdir: /Users/doug9425/testing/layered-config
collected 20 items                                                                                                                                                                                     

tests/test_config.py ...........F........                                                                                                                                                        [100%]

=============================================================================================== FAILURES ===============================================================================================
___________________________________________________________________________________________ test_munchifier ____________________________________________________________________________________________

sample_configs = '/private/tmp/pytest-of-doug9425/pytest-1/qe_config_tests0/cake.config'

    def test_munchifier(sample_configs):
        """Test conversion from config parser to munch."""
        # Munch has it's own tests, we're just spot checking our conversion function.
>       config_by_dots = munchify_config(load_cake(sample_configs, "L1"))

tests/test_config.py:187: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

config_parser = <configparser.ConfigParser object at 0x104626d68>

    def munchify_config(config_parser):
        """
        Create a ``munch`` version of the config_parser's data.
    
        ``munch`` allows both attribute and item access to it's data.
        See the `munch`_ documentation for details.
    
        Note: This is a one-time conversion,
        if the ``config_parser`` is subsequently updated,
        the returned ``munch`` will be unaffected.
        """
>       from munch import Munch
E       ModuleNotFoundError: No module named 'munch'

layered_config/__init__.py:255: ModuleNotFoundError
================================================================================= 1 failed, 19 passed in 0.15 seconds ==================================================================================
Traceback (most recent call last):
  File "./self_check.py", line 59, in <module>
    main()
  File "./self_check.py", line 55, in main
    self_check(do_setup=args.setup, verbose=not args.quiet)
  File "./self_check.py", line 34, in self_check
    check_call(command)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['poetry', 'run', 'pytest', '.']' returned non-zero exit status 1.
```