### PR TITLE
Pin pip below v 19.

### DIFF
--- a/env_setup.py
+++ b/env_setup.py
@@ -9,6 +9,7 @@ import argparse
 from subprocess import check_call
 
 commands_to_run = [
+    ["poetry", "run", "pip", "install", "--upgrade", "pip<19"],
     ["poetry", "install", "-E", "munch"],
     ["poetry", "run", "pre-commit", "install"],
 ]


### PR DESCRIPTION
This is really only needed for Python 3.7.3 which is where they up'd pip to v 19.
I did run it under a python 3.6.4, but would appreciate if someone would double check with another V3.6 python (or any Python <3.7.3) just to make sure.
