### PR TITLE
layered-config - not just tableread anymore!

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,7 +4,7 @@ Contributors
 This package was the result of collaborative dissussion and effort between:
 
 * Brad Brown @bradsbrown
-* Ryan Casperson @rbcasperson
+* Ryan Casperson @rbcasperson (Honorary, "undocumented", Editor-in-Chief)
 * Lewis Franklin @brolewis
 * Doug Philips @dgou
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -4,7 +4,7 @@ Contributors
 This package was the result of collaborative dissussion and effort between:
 
 * Brad Brown @bradsbrown
-* Ryan Casperson @rbcasperson (Honorary, "undocumented", Editor-in-Chief)
+* Ryan Casperson @rbcasperson (Honorary, "unofficial", Editor-in-Chief)
 * Lewis Franklin @brolewis
 * Doug Philips @dgou
 

--- a/sphinx_docs/conf.py
+++ b/sphinx_docs/conf.py
@@ -32,7 +32,7 @@ release = version
 
 # General information about your project.
 project = "layered-config - library for layering config files"
-copyright = "2018, Doug Philips and Ryan Casperson"  # noqa
+copyright = "2018, Doug Philips"  # noqa
 author = "Doug Philips"
 
 ######################################################

--- a/sphinx_docs/conf.py
+++ b/sphinx_docs/conf.py
@@ -31,9 +31,9 @@ release = version
 ######################################################
 
 # General information about your project.
-project = "Tableread - turn a rST table into a Python object!"
-copyright = "2018, Brad Brown"  # noqa
-author = "Brad Brown"
+project = "layered-config - library for layering config files"
+copyright = "2018, Doug Philips and Ryan Casperson"  # noqa
+author = "Doug Philips"
 
 ######################################################
 # BELOW HERE YOU SHOULD BE ABLE TO LEAVE AS-IS.


### PR DESCRIPTION
Tweak some doc cut'n'paste that we missed.
This mostly shows up in the upper left hand corner of:
https://jolly-good-toolbelt.github.io/layered-config/index.html
and built with this PR:
https://dgou.github.io/layered-config/index.html