### PR TITLE
Remove readline line from pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [tool.poetry]
 name = "layered-config"
-version = "2.0.1"
+version = "2.0.2"
 description = "A tool for managing layered config files!"
 authors = ["Doug Philips <dgou@mac.com>"]
 license = "MIT"
-readme = "README.rst"
 homepage = "https://github.com/jolly-good-toolbelt/layered-config"
 repository = "https://github.com/jolly-good-toolbelt/layered-config"
 documentation = "https://jolly-good-toolbelt.github.io/layered-config/"


### PR DESCRIPTION
Interim PR to get this publishable. Restoring the readme line for a followup PR.

That is used to generate a long description,
and the long description so generated causes a problem trying
to upload to PyPI: `400 Client Error: The description failed to render for 'text/x-rst'. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/`

Per Ryan's research, these links may be helpful
in being able to add this line back in:
https://github.com/sdispater/poetry/issues/1108
https://github.com/zalando-incubator/Transformer/pull/60/files